### PR TITLE
Add loadGenData method

### DIFF
--- a/source/dMatrix.r
+++ b/source/dMatrix.r
@@ -526,6 +526,23 @@ setGenData<-function(fileIn,header,dataType,distributed.by='rows',n=NULL,p=NULL,
 
     if(returnData){ return(genData) }
 }
+
+loadGenData<-function(path){
+    if(!file.exists(paste0(path,'/genData.RData'))){
+        stop(paste('Could not find a genData object in path',path))
+    }
+    cwd<-getwd()
+    setwd(path)
+    load('genData.RData', .GlobalEnv)
+    # Open all chunks for reading (we do not store absolute paths to ff files,
+    # so this has to happen in the same working directory)
+    chunks<-chunks(genData@geno)
+    for(i in 1:nrow(chunks)){
+        open(genData@geno[[i]])
+    }
+    # Restore working directory
+    setwd(cwd)
+}
  
 ## END OF MAKE makeGenosFF ###############################################################
 apply.DMatrix<-function(X,MARGIN,FUN,chunkSize=1e3,verbose=TRUE,...){


### PR DESCRIPTION
Ana ran into the problem of trying to load `genData.RData` from a different directory than the one where the *.bin files are stored. I think this will be a very common mistake, so I looked for a way to solve it. It seems like once the connection to the *.bin files is opened, we can freely change working directories. This code essentially switches to the path that contains a genData object, loads it, opens the ff objects, and switches back to the previous working directory. I hope the connection to the ff objects stays open, otherwise we have to find a different solution.