### PR TITLE
Better tempdir handling

### DIFF
--- a/R/dMatrix.R
+++ b/R/dMatrix.R
@@ -13,7 +13,10 @@ rDMatrix<-setClass('rDMatrix',contains='list')
 setClassUnion('dMatrix',c('cDMatrix','rDMatrix'))
 
 #' @export
-setMethod('initialize','cDMatrix',function(.Object,nrow=1,ncol=1,vmode='byte',folderOut=tempdir(),nChunks=NULL,dimorder=c(2,1)){
+setMethod('initialize','cDMatrix',function(.Object,nrow=1,ncol=1,vmode='byte',folderOut=NULL,nChunks=NULL,dimorder=c(2,1)){
+    if(is.null(folderOut)){
+        folderOut<-paste0(tempdir(),'/dMatrix-',randomString())
+    }
     if(file.exists(folderOut)){
         stop(paste('Output folder',folderOut,'already exists. Please move it or pick a different one.'))
     }
@@ -43,7 +46,10 @@ setMethod('initialize','cDMatrix',function(.Object,nrow=1,ncol=1,vmode='byte',fo
 })
 
 #' @export
-setMethod('initialize','rDMatrix',function(.Object,nrow=1,ncol=1,vmode='byte',folderOut=tempdir(),nChunks=NULL,dimorder=c(2,1)){
+setMethod('initialize','rDMatrix',function(.Object,nrow=1,ncol=1,vmode='byte',folderOut=NULL,nChunks=NULL,dimorder=c(2,1)){
+    if(is.null(folderOut)){
+        folderOut<-paste0(tempdir(),'/dMatrix-',randomString())
+    }
     if(file.exists(folderOut)){
         stop(paste('Output folder',folderOut,'already exists. Please move it or pick a different one.'))
     }
@@ -1107,4 +1113,8 @@ simPED<-function(filename,n,p,genoChars=1:4,na.string=0,propNA=.02,returnGenos=F
     if(returnGenos){
         return(OUT)
     }
+}
+
+randomString <- function () {
+    paste(sample(c(0:9, letters, LETTERS), size = 5, replace = TRUE), collapse = "")
 }

--- a/R/dMatrix.R
+++ b/R/dMatrix.R
@@ -563,8 +563,15 @@ setGenData<-function(fileIn,header,dataType,distributed.by='columns',n=NULL,p=NU
         stop(paste('Output folder',folderOut,'already exists. Please move it or pick a different one.'))
     }
     dir.create(folderOut)
-    if(!(dataType%in%c('character','integer','numeric'))){ stop('dataType must be either character, integer or numeric')}
-    vMode<-ifelse( dataType%in%c('character','integer'),'byte','double')
+
+    if(!dataType%in%c('character','integer','numeric')){
+        stop('dataType must be either character, integer or numeric')
+    }
+    if(!distributed.by%in%c('columns','rows')){
+        stop('distributed.by must be either columns or rows')
+    }
+
+    vMode<-ifelse(dataType%in%c('character','integer'),'byte','double')
 
     if(is.null(n)){
         # gzfile and readLines throw some warnings, but since it works, let's
@@ -605,8 +612,6 @@ setGenData<-function(fileIn,header,dataType,distributed.by='columns',n=NULL,p=NU
 
     pheno<-matrix(nrow=n,ncol=nColSkip)
     colnames(pheno)<-phtNames
-
-	if(!distributed.by%in%c('columns','rows')){stop('distributed.by must be either columns or rows') }
 
     geno<-new(ifelse(distributed.by=='columns','cDMatrix','rDMatrix'),nrow=n,ncol=p,vmode=vMode,folderOut=folderOut,nChunks=nChunks,dimorder=dimorder)
     colnames(geno)<-mrkNames

--- a/R/dMatrix.R
+++ b/R/dMatrix.R
@@ -14,6 +14,10 @@ setClassUnion('dMatrix',c('cDMatrix','rDMatrix'))
 
 #' @export
 setMethod('initialize','cDMatrix',function(.Object,nrow=1,ncol=1,vmode='byte',folderOut=tempdir(),nChunks=NULL,dimorder=c(2,1)){
+    if(file.exists(folderOut)){
+        stop(paste('Output folder',folderOut,'already exists. Please move it or pick a different one.'))
+    }
+    dir.create(folderOut)
     if(is.null(nChunks)){
         chunkSize<-min(nrow,floor(.Machine$integer.max/ncol/1.2))
         nChunks<-ceiling(nrow/chunkSize)
@@ -40,6 +44,10 @@ setMethod('initialize','cDMatrix',function(.Object,nrow=1,ncol=1,vmode='byte',fo
 
 #' @export
 setMethod('initialize','rDMatrix',function(.Object,nrow=1,ncol=1,vmode='byte',folderOut=tempdir(),nChunks=NULL,dimorder=c(2,1)){
+    if(file.exists(folderOut)){
+        stop(paste('Output folder',folderOut,'already exists. Please move it or pick a different one.'))
+    }
+    dir.create(folderOut)
     if(is.null(nChunks)){
         chunkSize<-min(ncol,floor(.Machine$integer.max/nrow/1.2))
         nChunks<-ceiling(ncol/chunkSize)
@@ -562,8 +570,6 @@ setGenData<-function(fileIn,header,dataType,distributed.by='columns',n=NULL,p=NU
     if(file.exists(folderOut)){
         stop(paste('Output folder',folderOut,'already exists. Please move it or pick a different one.'))
     }
-    dir.create(folderOut)
-
     if(!dataType%in%c('character','integer','numeric')){
         stop('dataType must be either character, integer or numeric')
     }

--- a/tests/testthat/test-setgendata.r
+++ b/tests/testthat/test-setgendata.r
@@ -2,10 +2,6 @@ library(dMatrix)
 
 context("dMatrix")
 
-randomString <- function () {
-    paste(sample(c(0:9, letters, LETTERS), size = 5, replace = TRUE), collapse = "")
-}
-
 # Create temporary directory
 tmpPath <- paste0("/tmp/dMatrix-", randomString(), "/")
 dir.create(tmpPath)


### PR DESCRIPTION
This is an extension of #36. The constructor used a default `folderOut` that was not unique (`tempdir()`). When subsequent dMatrices were created, ff automatically loaded the existing ones, leading to strange error messages.