### PR TITLE
Fix wrong variable name in GWAS.SKAT

### DIFF
--- a/R/genData.R
+++ b/R/genData.R
@@ -449,7 +449,7 @@ GWAS.SKAT<-function(formula,data,groups,plot=FALSE,verbose=FALSE,min.pValue=1e-1
     }
     
     for(i in 1:p){
-        Z<-genData@geno[,groups==levels[i],drop=FALSE]
+        Z<-data@geno[,groups==levels[i],drop=FALSE]
         fm<-SKAT::SKAT(Z=Z,obj=H0,...)
         OUT[i,]<-c(ncol(Z),fm$p.value)
         


### PR DESCRIPTION
`genData` might not be in the scope, use formal `data` instead.